### PR TITLE
Add systemd units

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 expose the libsecret dbus api with pass as backend
 
+# Installing systemd and dbus services
+Install [dbus-org.freedesktop.secrets.service](systemd/dbus-org.freedesktop.secrets.service) in `/usr/share/dbus-1/services/` and [org.freedesktop.secrets.service](systemd/org.freedesktop.secrets.service) in `/usr/local/lib/systemd/user/`.  `dbus-org.freedesktop.secrets.service` assumes that the `pass_secret_service` executable is installed in `/usr/local/bin/pass_secret_service`.  If that is not the case on your system, then you will need to modify the `ExecStart` path.
+
+Once these files are in place, you will need to run `systemctl daemon-reload`. Now whenever a program tries to access the libsercret dbus API, dbus should start `pass_secret_service` automatically.
+
 ## References
 
 * [secret_service dbus api](https://specifications.freedesktop.org/secret-service/)

--- a/systemd/dbus-org.freedesktop.secrets.service
+++ b/systemd/dbus-org.freedesktop.secrets.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Expose the libsecret dbus api with pass as backend
+
+[Service]
+BusName=org.freedesktop.secrets
+ExecStart=/usr/local/bin/pass_secret_service

--- a/systemd/org.freedesktop.secrets.service
+++ b/systemd/org.freedesktop.secrets.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.freedesktop.secrets
+Exec=/bin/false
+SystemdService=dbus-org.freedesktop.secrets.service


### PR DESCRIPTION
* Add a systemd service for pass_secret_service.
* Add a dbus service that connects to the systemd service.
* Document installation of these service files.

These have been tested on my NixOS system, and it allows for `pass_secret_service` to be started as a systemd user service automatically when an application tries to talk to the libsecret dbus API.