### PR TITLE
Add support for native `pass` backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ relgnupghome ::= test/.gnupghome
 export GNUPGHOME ::= $(projectdir)/$(relgnupghome)
 gpg_key_id ::= "8c2a59a7"
 relpassstore ::= test/.test-password-store
+pass ::= pypass
 export PASSWORD_STORE_DIR ::= $(projectdir)/$(relpassstore)
 
 .PHONY: all test coverage style clean clean-pycache clean-build
@@ -10,7 +11,7 @@ export PASSWORD_STORE_DIR ::= $(projectdir)/$(relpassstore)
 all: style test
 
 test: | $(relpassstore)
-	dbus-run-session -- pytest-3 -v test
+	dbus-run-session -- pytest-3 -v test --asyncio-mode=auto
 
 coverage: | $(relpassstore)
 	dbus-run-session -- python3 -m coverage run -m pytest -v test
@@ -28,7 +29,7 @@ $(relgnupghome): test/test_key.asc test/test_ownertrust.txt
 
 $(relpassstore): | $(relgnupghome)
 	@echo "===== Preparing password store in $(relpassstore) ====="
-	pypass init -p $(relpassstore) $(gpg_key_id)
+	$(pass) init -p $(relpassstore) $(gpg_key_id)
 
 clean: clean-test-environment clean-pycache clean-build
 

--- a/pass_secret_service/common/native_pass.py
+++ b/pass_secret_service/common/native_pass.py
@@ -1,7 +1,6 @@
 import subprocess
 import os
 
-DEFAULT_STORE_DIR = "/tmp/.password-store"
 DEFAULT_PASS = "pass"
 
 class NativePasswordStore:

--- a/pass_secret_service/common/native_pass.py
+++ b/pass_secret_service/common/native_pass.py
@@ -1,0 +1,31 @@
+import subprocess
+import os
+
+DEFAULT_STORE_DIR = "/tmp/.password-store"
+DEFAULT_PASS = "pass"
+
+class NativePasswordStore:
+    def __init__(self, use_pass=None, path=None):
+        self.pass_cmd = use_pass or DEFAULT_PASS
+        self.path = path
+
+    def _pass(self, *args, **kwargs):
+        env = os.environ
+        if self.path is not None:
+            env.update({'PASSWORD_STORE_DIR': self.path})
+
+        proc = subprocess.run([self.pass_cmd, *args],
+            check=True,
+            text=True,
+            capture_output=True,
+            env=env,
+            **kwargs
+        )
+
+        return proc
+
+    def get_decrypted_password(self, passname):
+        return self._pass("show", passname).stdout.removesuffix("\n")
+
+    def insert_password(self, passname, password):
+        self._pass("insert", "--echo", passname, input=password)

--- a/pass_secret_service/common/pass_store.py
+++ b/pass_secret_service/common/pass_store.py
@@ -2,19 +2,30 @@ import os
 import shutil
 import uuid
 import json
-from pypass import PasswordStore
 
+try:
+    from pypass import PasswordStore
 
-# Work around a typo in pypass
-if not hasattr(PasswordStore, "get_decrypted_password"):
-    PasswordStore.get_decrypted_password = PasswordStore.get_decypted_password
+    # Work around a typo in pypass
+    if not hasattr(PasswordStore, "get_decrypted_password"):
+        PasswordStore.get_decrypted_password = PasswordStore.get_decypted_password
+
+except ImportError:
+    from .native_pass import NativePasswordStore
+    PasswordStore = NativePasswordStore
 
 
 class PassStore:
     PREFIX = "secret_service"
 
-    def __init__(self, *args, **kwargs):
-        self._store = PasswordStore(*args, **kwargs)
+    def __init__(self, *args, use_pass=None, **kwargs):
+        if not use_pass:
+            self._store = PasswordStore(*args, **kwargs)
+
+        else:
+            from .native_pass import NativePasswordStore
+            self._store = NativePasswordStore(use_pass=use_pass, **kwargs)
+
         self.base_path = os.path.join(self._store.path, self.PREFIX)
         if not os.path.exists(self.base_path):
             os.makedirs(self.base_path)

--- a/pass_secret_service/pass_secret_service.py
+++ b/pass_secret_service/pass_secret_service.py
@@ -30,10 +30,10 @@ async def register_service(pass_store):
     return service
 
 
-def _main(path, verbose):
+def _main(path, pass_, verbose):
     if verbose:
         logging.basicConfig(level=20)
-    pass_store = PassStore(**({"path": path} if path else {}))
+    pass_store = PassStore(use_pass=pass_, **({"path": path} if path else {}))
     mainloop = asyncio.get_event_loop()
     mainloop.add_signal_handler(signal.SIGTERM, functools.partial(term_loop, mainloop))
     mainloop.add_signal_handler(signal.SIGINT, functools.partial(term_loop, mainloop))
@@ -51,9 +51,10 @@ def _main(path, verbose):
 
 @click.command()
 @click.option("--path", help="path to the password store (optional)")
+@click.option("-e", "pass_", help="use given pass executable")
 @click.option("-v", "--verbose", help="be verbose", is_flag=True, default=False)
-def main(path, verbose):
-    _main(path, verbose)
+def main(path, pass_, verbose):
+    _main(path, pass_, verbose)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
I implemented a basic backend for the native `pass` binary as suggested by #35.
It can be enabled by passing `-e <pass-binary>` to `pass_secret_service`. Furthermore
it is used as a fallback when `pypass` is not found.

All tests are passing.

Looking foward, I suggest dropping `pypass` and only using `pass`, since there does not seem to be active development and I don't see any benefit in using `pypass` instead of the main application.